### PR TITLE
do not truncate line when sauron-max-line-length is nil

### DIFF
--- a/sauron.el
+++ b/sauron.el
@@ -350,12 +350,12 @@ PROPS an origin-specific property list that will be passed to the hook funcs."
     (let* ((line (sr-event-line origin prio msg))
 	    ;; add the callback as a text property, remove any embedded newlines,
 	    ;; truncate if necessary append a newline
-	    (line (concat
-		    (truncate-string-to-width
-		      (propertize (replace-regexp-in-string "\n" " " line)
-			'callback func)
-		      sauron-max-line-length 0 nil t)
-		      "\n"))
+	    (line (replace-regexp-in-string "\n" " " line))
+	    (line (if sauron-max-line-length
+		      (truncate-string-to-width
+		       line sauron-max-line-length 0 nil t)
+		    line))
+	    (line (concat (propertize line 'callback func) "\n"))
 	    (inhibit-read-only t))
       (sr-create-buffer-maybe) ;; create buffer if it did not exist yet
       (with-current-buffer sr-buffer


### PR DESCRIPTION
I fixed sauron-add-event to work as sauron-max-line-length docstring describes: "If set to nil, there is no maximum."
