### PR TITLE
add 'sauron-hide-mode-line' variable, to hide the modeline in the sauron frame

### DIFF
--- a/sauron.el
+++ b/sauron.el
@@ -84,6 +84,9 @@ nick. Must be < 65536")
 (defvar sauron-sticky-frame nil
   "If t, show the sauron frame on every (virtual) desktop.")
 
+(defvar sauron-hide-mode-line nil
+  "If t, hide the modeline in the sauron frame.")
+
 (defvar sauron-scroll-to-bottom t
   "Wether to automatically scroll the sauron window to the bottom
 when new events arrive. Set to nil to prevent this.")
@@ -422,6 +425,8 @@ frame/window."
 		       (unsplittable . t) (sticky . ,sauron-sticky-frame))
 		    (x-parse-geometry sauron-frame-geometry))))
 	    (modify-frame-parameters nil frame-params))))
+	(if sauron-hide-mode-line
+	  (setq mode-line-format nil))
     (set-window-dedicated-p (selected-window) t)))
 
 (defun sr-hide ()


### PR DESCRIPTION
I think it looks compact without a mode-line in the sauron window. So, I add a variable to control it.
