### PR TITLE
sauron-emms module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ FILES=	sauron.el		\
 	sauron-jabber.el	\
 	sauron-org.el		\
 	sauron-notifications.el \
-	sauron-twittering.el
+	sauron-twittering.el \
+	sauron-emms.el
 
 ELPA_FILES = $(FILES)	\
 	sauron-pkg.el

--- a/README.org
+++ b/README.org
@@ -238,6 +238,7 @@
    - *identica* - for =identica-mode=, the social-network site
    - *twittering* - for =twittering-mode=, the emacs twitter client
    - *jabber* - for =jabber=, the IM protocol (XMPP)
+   - *emms* - the Emacs Multimedia System.
 
      By default, =sauron= tries to load all of them; this should work, even if
      you don't have some of these packages (they simply won't be activated).

--- a/sauron-emms.el
+++ b/sauron-emms.el
@@ -1,0 +1,66 @@
+;;; sauron-emms.el --- EMMS notifications for sauron
+;;
+;; Copyright (C) 2012 Tom Willemsen <tom@ryuslash.org>
+
+;; This file is not part of GNU Emacs.
+;;
+;; Sauron is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; Sauron is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;  For documentation, please see:
+;;  https://github.com/djcb/sauron/blob/master/README.org
+
+;;; Code:
+(require 'emms nil 'noerror)
+
+(defvar sr-emms-running nil
+  "*internal* whether sauron emms is running.")
+
+(defun sauron-emms-start ()
+  "Start listening to EMMS."
+  (if (not (boundp 'emms-version))
+      (progn
+        (message "sauron-emms not available")
+        nil)
+    (unless sr-emms-running
+      (add-hook 'emms-player-finished-hook 'sr-emms-player-finished-func)
+      (add-hook 'emms-playlist-selection-changed-hook
+                'sr-emms-playlist-selection-changed-func)
+      (setq sr-emms-running t))
+    t))
+
+(defun sauron-emms-stop ()
+  "Stop listening to EMMS."
+  (when sr-emms-running
+    (remove-hook 'emms-player-finished-hook 'sr-emms-player-finished-func)
+    (remove-hook 'emms-playlist-selection-changed-hook
+                 'sr-emms-playlist-selection-changed-func)
+    (setq sr-emms-running nil)))
+
+(defun sr-emms-player-finished-func ()
+  "Notify when EMMS is finished playing."
+  (sauron-add-event 'emms 3 "Playlist finished" 'emms))
+
+(defun sr-emms-playlist-selection-changed-func ()
+  "Notify of song change."
+  (sauron-add-event
+   'emms 3
+   (format emms-show-format
+           (emms-track-description
+            (emms-playlist-current-selected-track)))
+   'emms))
+
+(provide 'sauron-emms)
+
+;;; sauron-emms.el ends here

--- a/sauron.el
+++ b/sauron.el
@@ -39,10 +39,10 @@
 
 (defvar sauron-modules
   '(sauron-erc sauron-dbus sauron-org sauron-notifications
-     sauron-twittering sauron-jabber sauron-identica)
+     sauron-twittering sauron-jabber sauron-identica sauron-emms)
   "List of sauron modules to use. Currently supported are:
 sauron-erc, sauron-org and sauron-dbus, sauron-twittering,
-sauron-jabber, sauron-identica.")
+sauron-jabber, sauron-identica, sauron-emms.")
 
 (defvar sauron-separate-frame t
   "Show sauron in a separate frame; if set to nil (*experimental*),


### PR DESCRIPTION
sauron-emms shows the song that is currently playing whenever it
changes and when a playlist finishes playing.

In case you might like another one.

I thought about handling the `emms-paused-hook`, `emms-started-hook`, `emms-player-stopped-hook`, `emms-playlist-cleared-hook` and `emms-playlist-source-inserted-hook` hooks, but they all seem to be the result of user actions, so maybe not very useful to handle, even at low priority.

If you have any comments, suggestions or criticisms I'm always happy to work on them.
