### PR TITLE
Fix warning about using `map`.

### DIFF
--- a/sauron.el
+++ b/sauron.el
@@ -232,7 +232,7 @@ e.g. when using ERC.")
   (setq header-line-format
     (cons
       (make-string (floor (fringe-columns 'left t)) ?\s)
-      (map 'list
+      (mapcar
 	(lambda (elm)
 	  (let ((field (cdr (assoc (car elm) sr-column-name-alist)))
 		 (width (cdr elm)))


### PR DESCRIPTION
When byte-compiling I get a warning about using `map` at runtime.

Perhaps this is too rigorous, though, then you can disregard this. But it seems that `mapcar` does the same as `(map 'list ...`, though I might just be missing something of course.
