### PR TITLE
change default priority of jabber notifications for parity with ERC

### DIFF
--- a/README.org
+++ b/README.org
@@ -257,7 +257,7 @@
     won't get notified from the same nick for another 60 seconds (by default --
     see =sauron-nick-insensitivity=), so you won't get e.g. sound effects for
     each message in a private conversation.
-
+    
 *** org-mode / appt
 
     For org-mode, sauron adds functionality to =appt-disp-window-function= (but
@@ -367,13 +367,14 @@
 
 *** jabber
 
-    =sauron-jabber= shows events from =jabber.el=, this includes new messages, info
-    messages, presence alerts and lost connections.
+    =sauron-jabber= shows events from =jabber.el=, this includes new
+    messages, info messages, presence alerts and lost connections.
 
-    The info, presence and connection events get priority 2, so by default you won't
-    get to see these. The others get priority 3, so those /should/ be visible by
-    default.
-
+    All these events get priority 2 so by default you won't see
+    these. As with =erc=, change =sauron-watch-patterns= and/or
+    =sauron-watch-nicks= to filter messages that you want to get a
+    higher priority and thus be visible by default.
+    
 ** adding new modules
 
    It may be interesting to track other modules as well; this shouldn't be too

--- a/sauron-jabber.el
+++ b/sauron-jabber.el
@@ -65,7 +65,7 @@
 (defun sr-jabber-alert-message-func (from buffer text
                                                 proposed-alert)
   (let ((name (jabber-jid-displayname from)))
-    (sauron-add-event 'jabber 3 proposed-alert
+    (sauron-add-event 'jabber 2 proposed-alert
                       `(lambda ()
                          (sauron-switch-to-marker-or-buffer
                           ,(buffer-name buffer))))))
@@ -79,7 +79,7 @@
 
 (defun sr-jabber-alert-muc-func (nick group buffer text
                                             proposed-alert)
-  (sauron-add-event 'jabber 3 proposed-alert
+  (sauron-add-event 'jabber 2 proposed-alert
                     `(lambda ()
                        (sauron-switch-to-marker-or-buffer
                         ,(buffer-name buffer)))))


### PR DESCRIPTION
I thought it made sense to change the default priority of Jabber notifications so that nothing shows in the `sauron` window unless you are specifically tracking nicks or mentions, as with ERC.
