### PR TITLE
Change looping to count all lines

### DIFF
--- a/sauron.el
+++ b/sauron.el
@@ -504,10 +504,12 @@ with the respective numbers for those."
       (save-excursion
 	(let ((handled-num 0) (unhandled-num 0))
 	  (goto-char (point-min))
-	  (while (re-search-forward "\n" nil t)
-	    (case (get-text-property (point) 'status)
-	      (handled (incf handled-num))
-	      (unhandled (incf unhandled-num))))
+	  (while
+	      (progn
+		(case (get-text-property (point) 'status)
+		  (handled (incf handled-num))
+		  (unhandled (incf unhandled-num)))
+		(re-search-forward "\n" nil t)))
 	  (cons handled-num unhandled-num))))))
 
 


### PR DESCRIPTION
There is a mistake by counting lines in the while-loop. The current code does not count all lines with the text-property 'handled' or 'unhandled' because the first statement in the while-loop is 're-search-forward' and then the case-statement. This has the effect that the first line will never be counted.

If you change the case-statement and the re-search-forward everything is ok.
