### PR TITLE
Minor Cleanup to sauron-dbus.el

### DIFF
--- a/sauron-dbus.el
+++ b/sauron-dbus.el
@@ -1,4 +1,4 @@
-;;; sauron-dbus.el --- a dbus tracking module, part of sauron
+;;; sauron-dbus.el --- a dbus tracking module, part of sauron -*-lexical-binding:t-*-
 ;;
 ;; Copyright (C) 2011 Dirk-Jan C. Binnema
 
@@ -30,7 +30,9 @@
 (defvar dbus-path-emacs nil)
 (defvar dbus-interface-introspectable nil)
 (when (not (fboundp 'dbus-unregister-service))
-  (defun dbus-unregister-service (&rest args) nil))
+  (defun dbus-unregister-service (&rest args)
+    (ignore args)
+    nil))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defvar sauron-dbus-cookie nil
@@ -134,7 +136,7 @@ return t, otherwise, return nil."
     (concat (propertize origin 'face 'sauron-highlight2-face)
       ":" message)
     ;; pseudo closure...
-    (lexical-let ((url url))
+    (let ((url url))
       (lambda() (browse-url url)))
     `(:url ,url :origin: ,origin))
   '(:boolean t))
@@ -147,7 +149,7 @@ return t, otherwise, return nil."
     (concat (propertize origin 'face 'sauron-highlight1-face)
       ": " message)
     ;; pseudo closure...
-    (lexical-let ((msg message))
+    (let ((msg message))
       (lambda() (message "%s" msg)))
     `(:origin origin))
   '(:boolean t))


### PR DESCRIPTION
Hi @djcb, thanks for Sauron (and mu4e). The cleanups for sauron-dbus.el are:

- Enable lexical binding for the whole file.
- require sauron as we are using SAURON-ADD-EVENT.
- DBUS-REGISTER-SERVER: ignore unused variable.

requiring sauron is something that should be done by each module according to flymake-mode. Although I'm unsure if it has any effect in the resulting byte-code?

Furthermore I want to replace `(require 'cl)` for `(require 'cl-lib)`. Although afaict nothing from `cl-lib` is being used, can we eliminate the line altogether?

I'm also wondering why do we want to continue loading if `(require 'dbus)` fails instead of just complaining to the user?
