### PR TITLE
Add org-mode support

### DIFF
--- a/sauron-appt.el
+++ b/sauron-appt.el
@@ -1,0 +1,96 @@
+;;; sauron-appt.el --- appointment tracking module, part of sauron
+;;
+;; Copyright (C) 2011-2012 Dirk-Jan C. Binnema
+
+;; This file is not part of GNU Emacs.
+;;
+;; Sauron is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; Sauron is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <http://www.gnu.appt/licenses/>.
+
+;;; Commentary:
+;;  For documentation, please see:
+;;  https://github.com/djcb/sauron/blob/master/README.appt
+
+;;; Code:
+(require 'appt nil 'noerror)
+(eval-when-compile (require 'cl))
+
+(defvar sauron-prio-appt-default 5
+  "Appt event default priority.")
+
+(defvar sauron-prio-appt-minutes-left-list
+  '((15 2)
+    (10 3)
+    (5 3)
+    (2 4))
+  "A list of pairs, where the first element of each pair is the
+number of minutes left before the appointment and the last
+element is an Appt event priority.")
+
+(defvar sr-appt-old-appt-func nil
+  "*internal* The old appt appt function.")
+
+(defvar sr-appt-running nil
+  "*internal* Whether the appt-backend is active.")
+
+(defun sauron-appt-start ()
+  "Start watching appt (appt)."
+  (if (not (boundp 'appt-disp-window-function))
+    (progn
+      (message "sauron-appt not available")
+      nil)
+    (unless sr-appt-running
+      (setq ;; save the old one, set the new one
+	sr-appt-old-appt-func appt-disp-window-function
+	appt-disp-window-function (function sr-appt-handler-func)
+	sr-appt-running t))
+    t))
+
+(defun sauron-appt-stop ()
+  "Stop checking appointments; restore the old function."
+  (when sr-appt-running
+    (setq
+      appt-disp-window-function (function sr-appt-old-appt-func)
+      sr-appt-running nil)))
+
+(defun sr-appt-handler-func (minutes-to-app new-time msg)
+  "Handle appointment reminders - the actual work is done in
+`sr-appt-handler-func-real', but this function deals with the
+possibility of getting lists for the `minutes-to-app' and `msg'
+arguments rather than single values."
+   (when minutes-to-app
+    (if (listp minutes-to-app)
+      (progn
+	(sr-appt-handler-func-real (car minutes-to-app) new-time (car msg))
+	(sr-appt-handler-func (cdr minutes-to-app) new-time (cdr msg)))
+      (sr-appt-handler-func-real minutes-to-app new-time msg))))
+
+(defun sr-appt-handler-func-real (minutes-to-app new-time msg)
+  "Handle appointment reminders. Also see: `sr-appt-handler-func.'"
+  (let* ((left (string-to-number minutes-to-app))
+         (prio (catch 'prio-found
+                 (dolist (pair sauron-prio-appt-minutes-left-list)
+                   (when (> left (car pair))
+                     (throw 'prio-found (car (last pair)))))
+                 sauron-prio-appt-default)))
+    (sauron-add-event 'appt prio
+      (format "%s minutes left before %s" minutes-to-app msg)
+      'appt-agenda-list
+      `(:minutes-left ,left :msg ,msg))
+    ;; call the old function as well, if defined
+    (when sr-appt-old-appt-func
+      (funcall sr-appt-old-appt-func minutes-to-app new-time msg))))
+
+(provide 'sauron-appt)
+
+;;; sauron-appt ends here

--- a/sauron-org.el
+++ b/sauron-org.el
@@ -1,34 +1,29 @@
-;;; sauron-org.el --- an org-mode (appt) tracking module, part of sauron
+;;; sauron-org.el --- org-mode tracking module, part of sauron -*- lexical-binding: t; -*-
 ;;
-;; Copyright (C) 2011-2012 Dirk-Jan C. Binnema
-
+;; Copyright (C) 2020 Jake Coble
+;;
+;; Author: Jake Coble <http://github/jakecoble>
+;; Maintainer: Jake Coble <j@kecoble.com>
+;; Created: May 14, 2020
+;; Modified: May 14, 2020
+;; Version: 0.0.1
+;; Keywords:
+;; Homepage: https://github.com/jakecoble/sauron-org
+;; Package-Requires: ((emacs "26.3") (cl-lib "0.5"))
+;;
 ;; This file is not part of GNU Emacs.
 ;;
-;; Sauron is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
-
-;; Sauron is distributed in the hope that it will be useful,
-;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
-
-;; You should have received a copy of the GNU General Public License
-;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
-
 ;;; Commentary:
-;;  For documentation, please see:
-;;  https://github.com/djcb/sauron/blob/master/README.org
-
+;;
+;;  org-mode tracking module, part of sauron
+;;
 ;;; Code:
-(require 'appt nil 'noerror)
-(eval-when-compile (require 'cl))
 
-;; this is really about 'appt', not 'org', but anyway...
+(require 'org)
+(require 'cl)
 
 (defvar sauron-prio-org-default 5
-  "Org event default priority.")
+  "Default event priority for org-mode headings.")
 
 (defvar sauron-prio-org-minutes-left-list
   '((15 2)
@@ -36,63 +31,78 @@
     (5 3)
     (2 4))
   "A list of pairs, where the first element of each pair is the
-number of minutes left before the appointment and the last
-element is an Org event priority.")
+number of minutes left before the deadline and the last
+element is an org-mode heading priority.")
 
-(defvar sr-org-old-appt-func nil
-  "*internal* The old org appt function.")
+(defvar sauron-org-refresh-interval 5
+  "Length of time between rebuilding the heading list specified in minutes.")
 
-(defvar sr-org-running nil
-  "*internal* Whether the org-backend is active.")
+(defvar sauron-org--heading-list '()
+  "List of headings that sauron-org is currently tracking.")
+
+(defvar sauron-org--refresh-timer nil
+  "Timer that rebuilds the list of org headings we're tracking.")
+
+(defun sauron-org-add-timers (heading time)
+  "Add a timer for every time interval."
+  (remove-if #'null
+             (mapcar
+              (lambda (interval)
+                (let ((priority (cadr interval))
+                      (target-time (seconds-to-time
+                                      (- (time-to-seconds time)
+                                        (* (car interval) 60)))))
+                  (if (time-less-p nil target-time)
+                      (run-at-time target-time nil
+                        (lambda ()
+                          (sauron-add-event 'org priority heading))))))
+              sauron-prio-org-minutes-left-list)))
+
+(defun sauron-org-maybe-add-heading ()
+  "Add heading at point if it is scheduled or has a deadline."
+  (let ((heading (org-get-heading))
+        (scheduled (org-get-scheduled-time (point)))
+        (deadline (org-get-deadline-time (point))))
+    (if (and scheduled (time-less-p nil scheduled))
+        (cl-pushnew
+         `(:heading ,heading
+           :time ,scheduled
+           :type :scheduled
+           :timers ,(sauron-org-add-timers heading scheduled))
+          sauron-org--heading-list))
+
+    (if (and deadline (time-less-p nil deadline))
+        (cl-pushnew
+         `(:heading ,heading
+           :time ,deadline
+           :type :deadline
+           :timers ,(sauron-org-add-timers heading deadline))
+          sauron-org--heading-list))))
+
+(defun sauron-org--clear-heading-list ()
+  "Cancel all the timers in the heading list and set it to nil."
+  (dolist (heading sauron-org--heading-list)
+    (mapcar #'cancel-timer (plist-get heading :timers)))
+
+  (setq sauron-org--heading-list '()))
+
+(defun sauron-org-rebuild-heading-list ()
+  "Scan all agenda files to build the heading list."
+  (sauron-org--clear-heading-list)
+
+  (org-map-entries
+   #'sauron-org-maybe-add-heading t 'agenda))
 
 (defun sauron-org-start ()
-  "Start watching org (appt)."
-  (if (not (boundp 'appt-disp-window-function))
-    (progn
-      (message "sauron-org not available")
-      nil)
-    (unless sr-org-running
-      (setq ;; save the old one, set the new one
-	sr-org-old-appt-func appt-disp-window-function
-	appt-disp-window-function (function sr-org-handler-func)
-	sr-org-running t))
-    t))
+  "Start watching org-mode."
+  (setq sauron-org--refresh-timer
+        (run-at-time nil (* sauron-org-refresh-interval 60) #'sauron-org-rebuild-heading-list)))
 
 (defun sauron-org-stop ()
-  "Stop checking appointments; restore the old function."
-  (when sr-org-running
-    (setq
-      appt-disp-window-function (function sr-org-old-appt-func)
-      sr-org-running nil)))
-
-(defun sr-org-handler-func (minutes-to-app new-time msg)
-  "Handle appointment reminders - the actual work is done in
-`sr-org-handler-func-real', but this function deals with the
-possibility of getting lists for the `minutes-to-app' and `msg'
-arguments rather than single values."
-   (when minutes-to-app
-    (if (listp minutes-to-app)
-      (progn
-	(sr-org-handler-func-real (car minutes-to-app) new-time (car msg))
-	(sr-org-handler-func (cdr minutes-to-app) new-time (cdr msg)))
-      (sr-org-handler-func-real minutes-to-app new-time msg))))
-
-(defun sr-org-handler-func-real (minutes-to-app new-time msg)
-  "Handle appointment reminders. Also see: `sr-org-handler-func.'"
-  (let* ((left (string-to-number minutes-to-app))
-         (prio (catch 'prio-found
-                 (dolist (pair sauron-prio-org-minutes-left-list)
-                   (when (> left (car pair))
-                     (throw 'prio-found (car (last pair)))))
-                 sauron-prio-org-default)))
-    (sauron-add-event 'org prio
-      (format "%s minutes left before %s" minutes-to-app msg)
-      'org-agenda-list
-      `(:minutes-left ,left :msg ,msg))
-    ;; call the old function as well, if defined
-    (when sr-org-old-appt-func
-      (funcall sr-org-old-appt-func minutes-to-app new-time msg))))
+  "Stop watching org-mode."
+  (cancel-timer sauron-org--refresh-timer)
+  (setq sauron-org--refresh-timer nil)
+  (sauron-org--clear-heading-list))
 
 (provide 'sauron-org)
-
-;;; sauron-org ends here
+;;; sauron-org.el ends here


### PR DESCRIPTION
Moves the appt stuff into `sauron-appt.el` and adds org-mode support to `sauron-org.el`.